### PR TITLE
Added logout endpoint and ws functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ http://localhost:3000/api/docs
 **Authentication:**
 - `POST /api/v1/auth/register` - Register a new user
 - `POST /api/v1/auth/login` - Login and receive JWT token
+- `POST /api/v1/auth/logout` - Logout user
 
 **Users:**
 - `GET /api/v1/users` - Get all users (public)
@@ -214,6 +215,7 @@ Connect to WebSocket at `ws://localhost:3000`
 - `deleted_message` - Message deleted
 - `changed_user` - User profile updated
 - `deleted_user` - User account deleted
+- `new_logout` - User logged out
 
 ## Project Structure
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -28,16 +28,11 @@ export class AuthController {
   });
 
   logout = asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
-    const username = req.user?.username;
-    const userId = req.user?.id;
-
-    if (!username || !userId) {
-      throw new UnauthorizedError('User authentication required');
-    }
+    const { username, id: userId } = req.user!;
 
     await authService.logout(username, userId);
-
-    logger.info(`User logged out: ${req.user?.username}`);
+    
+    logger.info(`User logged out: ${username}`);
 
     res.status(200).json({ success: true });
   });

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -39,7 +39,7 @@ export class AuthController {
 
     logger.info(`User logged out: ${req.user?.username}`);
 
-    res.status(200).json("{}");
+    res.status(200).json({ success: true });
   });
 }
 

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -28,8 +28,8 @@ export class AuthController {
   });
 
   logout = asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
-    let username = req.user?.username;
-    let userId = req.user?.id;
+    const username = req.user?.username;
+    const userId = req.user?.id;
 
     if (!username || !userId) {
       throw new UnauthorizedError('User authentication required');

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -4,7 +4,6 @@ import { RegisterDTO, LoginDTO } from '../validators/index.js';
 import { asyncHandler } from '../middleware/errorHandler.js';
 import logger from '../config/logger.js';
 import { AuthRequest } from '../middleware/auth.js';
-import { UnauthorizedError } from '../utils/errors.js';
 
 export class AuthController {
   register = asyncHandler(async (req: Request, res: Response): Promise<void> => {

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -3,6 +3,8 @@ import authService from '../services/auth.service.js';
 import { RegisterDTO, LoginDTO } from '../validators/index.js';
 import { asyncHandler } from '../middleware/errorHandler.js';
 import logger from '../config/logger.js';
+import { AuthRequest } from '../middleware/auth.js';
+import { UnauthorizedError } from '../utils/errors.js';
 
 export class AuthController {
   register = asyncHandler(async (req: Request, res: Response): Promise<void> => {
@@ -23,6 +25,21 @@ export class AuthController {
     logger.info(`User logged in: ${data.username}`);
 
     res.status(200).json(result);
+  });
+
+  logout = asyncHandler(async (req: AuthRequest, res: Response): Promise<void> => {
+    let username = req.user?.username;
+    let userId = req.user?.id;
+
+    if (!username || !userId) {
+      throw new UnauthorizedError('User authentication required');
+    }
+
+    await authService.logout(username, userId);
+
+    logger.info(`User logged out: ${req.user?.username}`);
+
+    res.status(200).json("{}");
   });
 }
 

--- a/src/infrastructure/websocket.ts
+++ b/src/infrastructure/websocket.ts
@@ -3,7 +3,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import logger from '../config/logger.js';
 
 export interface WebSocketMessage {
-  type: 'new_message' | 'changed_message' | 'deleted_message' | 'new_login' | 'changed_user' | 'deleted_user';
+  type: 'new_message' | 'changed_message' | 'deleted_message' | 'new_login' | 'changed_user' | 'deleted_user' | 'new_logout';
   data: unknown;
 }
 

--- a/src/routes/v1/auth.routes.ts
+++ b/src/routes/v1/auth.routes.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import authController from '../../controllers/auth.controller.js';
 import { validate } from '../../middleware/validate.js';
 import { registerSchema, loginSchema } from '../../validators/index.js';
+import { authenticate } from '../../middleware/auth.js';
 
 const router = Router();
 
@@ -64,5 +65,22 @@ router.post('/register', validate(registerSchema), authController.register);
  *         description: Login successful
  */
 router.post('/login', validate(loginSchema), authController.login);
+
+/**
+ * @swagger
+ * /auth/logout:
+ *   post:
+ *     tags:
+ *       - Authentication
+ *     summary: Logout user
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: false
+ *     responses:
+ *       200:
+ *         description: Logout successful
+ */
+router.post('/logout', authenticate, authController.logout);
 
 export default router;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -74,7 +74,6 @@ export class AuthService {
    * Handles the logout and sends websocket event
    * @param username Username of the user logging out
    * @param userId ID of the user logging out
-   * @throws {UnauthorizedError} If credentials are invalid
    */
   async logout(username: string, userId: string){
     await userRepository.updateLastActivity(userId);

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -77,7 +77,6 @@ export class AuthService {
    * @throws {UnauthorizedError} If credentials are invalid
    */
   async logout(username: string, userId: string){
-    
     await userRepository.updateLastActivity(userId);
 
     const wsManager = getWebSocketManager();

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -69,6 +69,25 @@ export class AuthService {
       token,
     };
   }
+
+  /**
+   * Handles the logout and sends websocket event
+   * @param username Username of the user logging out
+   * @param userId ID of the user logging out
+   * @throws {UnauthorizedError} If credentials are invalid
+   */
+  async logout(username: string, userId: string){
+    
+    await userRepository.updateLastActivity(userId);
+
+    const wsManager = getWebSocketManager();
+    if (wsManager) {
+      wsManager.broadcast({
+        type: 'new_logout',
+        data: { username: username },
+      });
+    }
+  }
 }
 
 export default new AuthService();

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -83,7 +83,7 @@ export class AuthService {
     if (wsManager) {
       wsManager.broadcast({
         type: 'new_logout',
-        data: { username: username },
+        data: { username },
       });
     }
   }

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -138,4 +138,25 @@ describe('Authentication API', () => {
       expect(response.status).toBe(400);
     });
   });
+
+  describe('POST /api/v1/auth/logout', () => {
+    it('should logout a user with authentication', async () => {
+      const user = await createTestUser();
+
+      const response = await request(app)
+        .post('/api/v1/auth/logout')
+        .set('Authorization', `Bearer ${user.token}`)
+        .send();
+
+      expect(response.status).toBe(200);
+    });
+
+    it('should reject logout without authentication', async () => {
+      const response = await request(app)
+        .post('/api/v1/auth/logout')
+        .send();
+
+      expect(response.status).toBe(401);
+    });
+  });
 });

--- a/src/tests/auth.test.ts
+++ b/src/tests/auth.test.ts
@@ -149,6 +149,8 @@ describe('Authentication API', () => {
         .send();
 
       expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('success');
+      expect(response.body.success).toBe(true);
     });
 
     it('should reject logout without authentication', async () => {


### PR DESCRIPTION
Added a basic logout functionality to complement the current backend. Main features of this commit/change:

- /auth/logout is a protected endpoint (Logically speaking should a logout button never be visible in frontend if a user is not logged in but it is still checked in backend to make sure)
- Testcases are simple but available
- Added a new event to websocket: "new_logout" which notifies the clients of a user change. This was the main reason for this commit as an up to date userlist in a chat application can only be achieved with an event from the WS. Neither the client disconnect nor a logout were published before.

I tried to keep it as similar to the existing codebase as possible and I tested it with the test cases and some manual testing.

Regards,
Nicola Sovic
HF24B